### PR TITLE
Cranify

### DIFF
--- a/R/enmtools.bc.R
+++ b/R/enmtools.bc.R
@@ -6,6 +6,7 @@
 #' @param report Optional name of an html file for generating reports
 #' @param overwrite TRUE/FALSE whether to overwrite a report file if it already exists
 #' @param nback Number of background points for models. In the case of bioclim models these are only used for evaluation.
+#' @param rts.reps The number of replicates to do for a Raes and ter Steege-style test of significance
 #' @param ... Arguments to be passed to bioclim()
 #'
 #' @export enmtools.bc
@@ -15,7 +16,7 @@
 #' data(iberolacerta.clade)
 #' enmtools.bc(iberolacerta.clade$species$monticola, env = euro.worldclim)
 
-enmtools.bc <- function(species, env = NA, test.prop = 0, report = NULL, overwrite = FALSE, nback = 1000, ...){
+enmtools.bc <- function(species, env = NA, test.prop = 0, report = NULL, overwrite = FALSE, nback = 1000, rts.reps = 0, ...){
 
   notes <- NULL
 
@@ -26,6 +27,7 @@ enmtools.bc <- function(species, env = NA, test.prop = 0, report = NULL, overwri
   test.data <- NA
   test.evaluation <- NA
   env.test.evaluation <- NA
+  rts.test <- NA
 
   if(test.prop > 0 & test.prop < 1){
     test.inds <- sample(1:nrow(species$presence.points), ceiling(nrow(species$presence.points) * test.prop))
@@ -67,6 +69,121 @@ enmtools.bc <- function(species, env = NA, test.prop = 0, report = NULL, overwri
     env.test.evaluation <- env.evaluate(temp.sp, this.bc, env)
   }
 
+
+  # Do Raes and ter Steege test for significance.  Turned off if eval == FALSE
+  if(rts.reps > 0){
+
+    rts.models <- list()
+
+    rts.geog.training <- c()
+    rts.geog.test <- c()
+    rts.env.training <- c()
+    rts.env.test <- c()
+
+    for(i in 1:rts.reps){
+
+      # Repeating analysis with scrambled pa points and then evaluating models
+      rep.species <- species
+      rep.rows <- sample(nrow(species$background.points), nrow(species$presence.points))
+      rep.species$presence.points <- species$background.points[rep.rows,]
+      rep.species$background.points <- rbind(species$background.points[-rep.rows,], species$presence.points)
+
+      this.bc <- dismo::bioclim(env, rep.species$presence.points[,1:2])
+
+      suitability <- predict(env, this.bc, type = "response")
+
+      thisrep.model.evaluation <-dismo::evaluate(rep.species$presence.points[,1:2], rep.species$background.points[,1:2],
+                                                 this.bc, env)
+      thisrep.env.model.evaluation <- env.evaluate(rep.species, this.bc, env)
+
+      rts.geog.training[i] <- thisrep.model.evaluation@auc
+      rts.env.training[i] <- thisrep.env.model.evaluation@auc
+
+      # I need to double check whether RTS tested models on same test data as empirical
+      # model, or whether they drew new holdouts for replicates.  Currently I'm just
+      # using the same test data for each rep.
+      if(test.prop > 0 & test.prop < 1){
+        thisrep.test.evaluation <-dismo::evaluate(test.data, rep.species$background.points[,1:2],
+                                                  this.bc, env)
+        temp.sp <- rep.species
+        temp.sp$presence.points <- test.data
+        thisrep.env.test.evaluation <- env.evaluate(temp.sp, this.bc, env)
+
+        rts.geog.test[i] <- thisrep.test.evaluation@auc
+        rts.env.test[i] <- thisrep.env.test.evaluation@auc
+      }
+      rts.models[[paste0("rep.",i)]] <- list(model = this.bc,
+                                             training.evaluation = model.evaluation,
+                                             env.training.evaluation = env.model.evaluation,
+                                             test.evaluation = test.evaluation,
+                                             env.test.evaluation = env.test.evaluation)
+    }
+
+    # Reps are all run now, time to package it all up
+
+    # Calculating p values
+    rts.geog.training.pvalue = mean(rts.geog.training > model.evaluation@auc)
+    rts.env.training.pvalue = mean(rts.env.training > env.model.evaluation@auc)
+    if(test.prop > 0){
+      rts.geog.test.pvalue <- mean(rts.geog.test > test.evaluation@auc)
+      rts.env.test.pvalue <- mean(rts.env.test > env.test.evaluation@auc)
+    } else {
+      rts.geog.test.pvalue <- NA
+      rts.env.test.pvalue <- NA
+    }
+
+    # Making plots
+    training.plot <- qplot(rts.geog.training, geom = "histogram", fill = "density", alpha = 0.5) +
+      geom_vline(xintercept = model.evaluation@auc, linetype = "longdash") +
+      xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+      ggtitle(paste("Model performance in geographic space on training data")) +
+      theme(plot.title = element_text(hjust = 0.5))
+
+    env.training.plot <- qplot(rts.env.training, geom = "histogram", fill = "density", alpha = 0.5) +
+      geom_vline(xintercept = env.model.evaluation@auc, linetype = "longdash") +
+      xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+      ggtitle(paste("Model performance in environmental space on training data")) +
+      theme(plot.title = element_text(hjust = 0.5))
+
+    # Make plots for test AUC distributions
+    if(test.prop > 0){
+      test.plot <- qplot(rts.geog.test, geom = "histogram", fill = "density", alpha = 0.5) +
+        geom_vline(xintercept = test.evaluation@auc, linetype = "longdash") +
+        xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+        ggtitle(paste("Model performance in geographic space on test data")) +
+        theme(plot.title = element_text(hjust = 0.5))
+
+      env.test.plot <- qplot(rts.env.test, geom = "histogram", fill = "density", alpha = 0.5) +
+        geom_vline(xintercept = env.test.evaluation@auc, linetype = "longdash") +
+        xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+        ggtitle(paste("Model performance in environmental space on test data")) +
+        theme(plot.title = element_text(hjust = 0.5))
+    } else {
+      test.plot <- NA
+      env.test.plot <- NA
+    }
+
+    rts.pvalues = list(rts.geog.training.pvalue = rts.geog.training.pvalue,
+                       rts.env.training.pvalue = rts.env.training.pvalue,
+                       rts.geog.test.pvalue = rts.geog.test.pvalue,
+                       rts.env.test.pvalue = rts.env.test.pvalue)
+    rts.distributions = list(rts.geog.training = rts.geog.training,
+                             rts.env.training = rts.env.training,
+                             rts.geog.test = rts.geog.test,
+                             rts.env.test = rts.env.test)
+    rts.plots = list(geog.training.plot = training.plot,
+                     env.training.plot = env.training.plot,
+                     geog.test.plot = test.plot,
+                     env.test.plot = env.test.plot)
+
+    rts.test <- list(rts.models = rts.models,
+                     rts.pvalues = rts.pvalues,
+                     rts.distributions = rts.distributions,
+                     rts.plots = rts.plots,
+                     rts.nreps = rts.reps)
+  }
+
+
   output <- list(species.name = species$species.name,
                  analysis.df = species$presence.points[,1:2],
                  test.data = test.data,
@@ -76,6 +193,7 @@ enmtools.bc <- function(species, env = NA, test.prop = 0, report = NULL, overwri
                  test.evaluation = test.evaluation,
                  env.training.evaluation = env.model.evaluation,
                  env.test.evaluation = env.test.evaluation,
+                 rts.test = rts.test,
                  suitability = suitability,
                  notes = notes)
 

--- a/R/enmtools.dm.R
+++ b/R/enmtools.dm.R
@@ -6,6 +6,7 @@
 #' @param report Optional name of an html file for generating reports
 #' @param overwrite TRUE/FALSE whether to overwrite a report file if it already exists
 #' @param nback Number of background points for models.  In the case of Domain, these are only used for evaluation.
+#' @param rts.reps The number of replicates to do for a Raes and ter Steege-style test of significance
 #' @param ... Arguments to be passed to bioclim()
 #'
 #' @export enmtools.dm
@@ -16,7 +17,7 @@
 #' enmtools.dm(iberolacerta.clade$species$monticola, env = euro.worldclim)
 
 
-enmtools.dm <- function(species, env = NA, test.prop = 0, report = NULL, nback = 1000, overwrite = FALSE, ...){
+enmtools.dm <- function(species, env = NA, test.prop = 0, report = NULL, nback = 1000, overwrite = FALSE, rts.reps = 0, ...){
 
   notes <- NULL
 
@@ -27,6 +28,7 @@ enmtools.dm <- function(species, env = NA, test.prop = 0, report = NULL, nback =
   test.data <- NA
   test.evaluation <- NA
   env.test.evaluation <- NA
+  rts.test <- NA
 
   if(test.prop > 0 & test.prop < 1){
     test.inds <- sample(1:nrow(species$presence.points), ceiling(nrow(species$presence.points) * test.prop))
@@ -47,14 +49,6 @@ enmtools.dm <- function(species, env = NA, test.prop = 0, report = NULL, nback =
 
   this.dm <- dismo::domain(env, species$presence.points[,1:2])
 
-  # This is a very weird hack that has to be done because dismo's evaluate function
-  # fails if the stack only has one layer.
-  if(length(names(env)) == 1){
-    oldname <- names(env)
-    env <- stack(env, env)
-    names(env) <- c(oldname, "dummyvar")
-  }
-
   model.evaluation <- dismo::evaluate(species$presence.points[,1:2], species$background.points[,1:2],
                                this.dm, env)
   env.model.evaluation <- env.evaluate(species, this.dm, env)
@@ -69,6 +63,119 @@ enmtools.dm <- function(species, env = NA, test.prop = 0, report = NULL, nback =
 
   suitability <- predict(env, this.dm, type = "response")
 
+  # Do Raes and ter Steege test for significance.  Turned off if eval == FALSE
+  if(rts.reps > 0){
+
+    rts.models <- list()
+
+    rts.geog.training <- c()
+    rts.geog.test <- c()
+    rts.env.training <- c()
+    rts.env.test <- c()
+
+    for(i in 1:rts.reps){
+
+      # Repeating analysis with scrambled pa points and then evaluating models
+      rep.species <- species
+      rep.rows <- sample(nrow(species$background.points), nrow(species$presence.points))
+      rep.species$presence.points <- species$background.points[rep.rows,]
+      rep.species$background.points <- rbind(species$background.points[-rep.rows,], species$presence.points)
+
+      this.dm <- dismo::domain(env, rep.species$presence.points[,1:2])
+
+      suitability <- predict(env, this.dm, type = "response")
+
+      thisrep.model.evaluation <-dismo::evaluate(rep.species$presence.points[,1:2], rep.species$background.points[,1:2],
+                                                 this.dm, env)
+      thisrep.env.model.evaluation <- env.evaluate(rep.species, this.dm, env)
+
+      rts.geog.training[i] <- thisrep.model.evaluation@auc
+      rts.env.training[i] <- thisrep.env.model.evaluation@auc
+
+      # I need to double check whether RTS tested models on same test data as empirical
+      # model, or whether they drew new holdouts for replicates.  Currently I'm just
+      # using the same test data for each rep.
+      if(test.prop > 0 & test.prop < 1){
+        thisrep.test.evaluation <-dismo::evaluate(test.data, rep.species$background.points[,1:2],
+                                                  this.dm, env)
+        temp.sp <- rep.species
+        temp.sp$presence.points <- test.data
+        thisrep.env.test.evaluation <- env.evaluate(temp.sp, this.dm, env)
+
+        rts.geog.test[i] <- thisrep.test.evaluation@auc
+        rts.env.test[i] <- thisrep.env.test.evaluation@auc
+      }
+      rts.models[[paste0("rep.",i)]] <- list(model = this.dm,
+                                             training.evaluation = model.evaluation,
+                                             env.training.evaluation = env.model.evaluation,
+                                             test.evaluation = test.evaluation,
+                                             env.test.evaluation = env.test.evaluation)
+    }
+
+    # Reps are all run now, time to package it all up
+
+    # Calculating p values
+    rts.geog.training.pvalue = mean(rts.geog.training > model.evaluation@auc)
+    rts.env.training.pvalue = mean(rts.env.training > env.model.evaluation@auc)
+    if(test.prop > 0){
+      rts.geog.test.pvalue <- mean(rts.geog.test > test.evaluation@auc)
+      rts.env.test.pvalue <- mean(rts.env.test > env.test.evaluation@auc)
+    } else {
+      rts.geog.test.pvalue <- NA
+      rts.env.test.pvalue <- NA
+    }
+
+    # Making plots
+    training.plot <- qplot(rts.geog.training, geom = "histogram", fill = "density", alpha = 0.5) +
+      geom_vline(xintercept = model.evaluation@auc, linetype = "longdash") +
+      xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+      ggtitle(paste("Model performance in geographic space on training data")) +
+      theme(plot.title = element_text(hjust = 0.5))
+
+    env.training.plot <- qplot(rts.env.training, geom = "histogram", fill = "density", alpha = 0.5) +
+      geom_vline(xintercept = env.model.evaluation@auc, linetype = "longdash") +
+      xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+      ggtitle(paste("Model performance in environmental space on training data")) +
+      theme(plot.title = element_text(hjust = 0.5))
+
+    # Make plots for test AUC distributions
+    if(test.prop > 0){
+      test.plot <- qplot(rts.geog.test, geom = "histogram", fill = "density", alpha = 0.5) +
+        geom_vline(xintercept = test.evaluation@auc, linetype = "longdash") +
+        xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+        ggtitle(paste("Model performance in geographic space on test data")) +
+        theme(plot.title = element_text(hjust = 0.5))
+
+      env.test.plot <- qplot(rts.env.test, geom = "histogram", fill = "density", alpha = 0.5) +
+        geom_vline(xintercept = env.test.evaluation@auc, linetype = "longdash") +
+        xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+        ggtitle(paste("Model performance in environmental space on test data")) +
+        theme(plot.title = element_text(hjust = 0.5))
+    } else {
+      test.plot <- NA
+      env.test.plot <- NA
+    }
+
+    rts.pvalues = list(rts.geog.training.pvalue = rts.geog.training.pvalue,
+                       rts.env.training.pvalue = rts.env.training.pvalue,
+                       rts.geog.test.pvalue = rts.geog.test.pvalue,
+                       rts.env.test.pvalue = rts.env.test.pvalue)
+    rts.distributions = list(rts.geog.training = rts.geog.training,
+                             rts.env.training = rts.env.training,
+                             rts.geog.test = rts.geog.test,
+                             rts.env.test = rts.env.test)
+    rts.plots = list(geog.training.plot = training.plot,
+                     env.training.plot = env.training.plot,
+                     geog.test.plot = test.plot,
+                     env.test.plot = env.test.plot)
+
+    rts.test <- list(rts.models = rts.models,
+                     rts.pvalues = rts.pvalues,
+                     rts.distributions = rts.distributions,
+                     rts.plots = rts.plots,
+                     rts.nreps = rts.reps)
+  }
+
   output <- list(species.name = species$species.name,
                  analysis.df = species$presence.points[,1:2],
                  test.data = test.data,
@@ -78,6 +185,7 @@ enmtools.dm <- function(species, env = NA, test.prop = 0, report = NULL, nback =
                  test.evaluation = test.evaluation,
                  env.training.evaluation = env.model.evaluation,
                  env.test.evaluation = env.test.evaluation,
+                 rts.test = rts.test,
                  suitability = suitability,
                  notes = notes)
 

--- a/R/enmtools.gam.R
+++ b/R/enmtools.gam.R
@@ -8,6 +8,7 @@
 #' @param nback Number of background points to draw from range or env, if background points aren't provided
 #' @param report Optional name of an html file for generating reports
 #' @param overwrite TRUE/FALSE whether to overwrite a report file if it already exists
+#' @param rts.reps The number of replicates to do for a Raes and ter Steege-style test of significance
 #' @param ... Arguments to be passed to gam()
 #'
 #' @export enmtools.gam
@@ -19,7 +20,7 @@
 
 
 
-enmtools.gam <- function(species, env, f = NULL, test.prop = 0, k = 4, nback = 1000, report = NULL, overwrite = FALSE, ...){
+enmtools.gam <- function(species, env, f = NULL, test.prop = 0, k = 4, nback = 1000, report = NULL, overwrite = FALSE, rts.reps = 0, ...){
 
   notes <- NULL
 
@@ -39,6 +40,7 @@ enmtools.gam <- function(species, env, f = NULL, test.prop = 0, k = 4, nback = 1
   test.data <- NA
   test.evaluation <- NA
   env.test.evaluation <- NA
+  rts.test <- NA
 
   if(test.prop > 0 & test.prop < 1){
     test.inds <- sample(1:nrow(species$presence.points), ceiling(nrow(species$presence.points) * test.prop))
@@ -83,6 +85,117 @@ enmtools.gam <- function(species, env, f = NULL, test.prop = 0, k = 4, nback = 1
   }
 
 
+  # Do Raes and ter Steege test for significance.  Turned off if eval == FALSE
+  if(rts.reps > 0){
+
+    rts.models <- list()
+
+    rts.geog.training <- c()
+    rts.geog.test <- c()
+    rts.env.training <- c()
+    rts.env.test <- c()
+
+    for(i in 1:rts.reps){
+
+      # Repeating analysis with scrambled pa points and then evaluating models
+      rts.df <- analysis.df
+      rts.df$presence <- rts.df$presence[sample(1:nrow(rts.df))]
+      this.gam <- gam(f, rts.df[,-c(1,2)], family="binomial", ...)
+
+      suitability <- predict(env, this.gam, type = "response")
+
+      thisrep.model.evaluation <-dismo::evaluate(species$presence.points[,1:2], species$background.points[,1:2],
+                                                 this.gam, env)
+      thisrep.env.model.evaluation <- env.evaluate(species, this.gam, env)
+
+      rts.geog.training[i] <- thisrep.model.evaluation@auc
+      rts.env.training[i] <- thisrep.env.model.evaluation@auc
+
+      # I need to double check whether RTS tested models on same test data as empirical
+      # model, or whether they drew new holdouts for replicates.  Currently I'm just
+      # using the same test data for each rep.
+      if(test.prop > 0 & test.prop < 1){
+        thisrep.test.evaluation <-dismo::evaluate(test.data, species$background.points[,1:2],
+                                                  this.gam, env)
+        temp.sp <- species
+        temp.sp$presence.points <- test.data
+        thisrep.env.test.evaluation <- env.evaluate(temp.sp, this.gam, env)
+
+        rts.geog.test[i] <- thisrep.test.evaluation@auc
+        rts.env.test[i] <- thisrep.env.test.evaluation@auc
+      }
+      rts.models[[paste0("rep.",i)]] <- list(model = this.gam,
+                                             training.evaluation = model.evaluation,
+                                             env.training.evaluation = env.model.evaluation,
+                                             test.evaluation = test.evaluation,
+                                             env.test.evaluation = env.test.evaluation)
+    }
+
+    # Reps are all run now, time to package it all up
+
+    # Calculating p values
+    rts.geog.training.pvalue = mean(rts.geog.training > model.evaluation@auc)
+    rts.env.training.pvalue = mean(rts.env.training > env.model.evaluation@auc)
+    if(test.prop > 0){
+      rts.geog.test.pvalue <- mean(rts.geog.test > test.evaluation@auc)
+      rts.env.test.pvalue <- mean(rts.env.test > env.test.evaluation@auc)
+    } else {
+      rts.geog.test.pvalue <- NA
+      rts.env.test.pvalue <- NA
+    }
+
+    # Making plots
+    training.plot <- qplot(rts.geog.training, geom = "histogram", fill = "density", alpha = 0.5) +
+      geom_vline(xintercept = model.evaluation@auc, linetype = "longdash") +
+      xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+      ggtitle(paste("Model performance in geographic space on training data")) +
+      theme(plot.title = element_text(hjust = 0.5))
+
+    env.training.plot <- qplot(rts.env.training, geom = "histogram", fill = "density", alpha = 0.5) +
+      geom_vline(xintercept = env.model.evaluation@auc, linetype = "longdash") +
+      xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+      ggtitle(paste("Model performance in environmental space on training data")) +
+      theme(plot.title = element_text(hjust = 0.5))
+
+    # Make plots for test AUC distributions
+    if(test.prop > 0){
+      test.plot <- qplot(rts.geog.test, geom = "histogram", fill = "density", alpha = 0.5) +
+        geom_vline(xintercept = test.evaluation@auc, linetype = "longdash") +
+        xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+        ggtitle(paste("Model performance in geographic space on test data")) +
+        theme(plot.title = element_text(hjust = 0.5))
+
+      env.test.plot <- qplot(rts.env.test, geom = "histogram", fill = "density", alpha = 0.5) +
+        geom_vline(xintercept = env.test.evaluation@auc, linetype = "longdash") +
+        xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+        ggtitle(paste("Model performance in environmental space on test data")) +
+        theme(plot.title = element_text(hjust = 0.5))
+    } else {
+      test.plot <- NA
+      env.test.plot <- NA
+    }
+
+    rts.pvalues = list(rts.geog.training.pvalue = rts.geog.training.pvalue,
+                       rts.env.training.pvalue = rts.env.training.pvalue,
+                       rts.geog.test.pvalue = rts.geog.test.pvalue,
+                       rts.env.test.pvalue = rts.env.test.pvalue)
+    rts.distributions = list(rts.geog.training = rts.geog.training,
+                             rts.env.training = rts.env.training,
+                             rts.geog.test = rts.geog.test,
+                             rts.env.test = rts.env.test)
+    rts.plots = list(geog.training.plot = training.plot,
+                     env.training.plot = env.training.plot,
+                     geog.test.plot = test.plot,
+                     env.test.plot = env.test.plot)
+
+    rts.test <- list(rts.models = rts.models,
+                     rts.pvalues = rts.pvalues,
+                     rts.distributions = rts.distributions,
+                     rts.plots = rts.plots,
+                     rts.nreps = rts.reps)
+  }
+
+
 
   output <- list(species.name = species$species.name,
                  formula = f,
@@ -94,6 +207,7 @@ enmtools.gam <- function(species, env, f = NULL, test.prop = 0, k = 4, nback = 1
                  test.evaluation = test.evaluation,
                  env.training.evaluation = env.model.evaluation,
                  env.test.evaluation = env.test.evaluation,
+                 rts.test = rts.test,
                  suitability = suitability,
                  notes = notes)
 

--- a/R/enmtools.maxent.R
+++ b/R/enmtools.maxent.R
@@ -6,6 +6,7 @@
 #' @param nback Number of background points to draw from range or env, if background points aren't provided
 #' @param report Optional name of an html file for generating reports
 #' @param overwrite TRUE/FALSE whether to overwrite a report file if it already exists
+#' @param rts.reps The number of replicates to do for a Raes and ter Steege-style test of significance
 #' @param ... Arguments to be passed to maxent()
 #'
 #' @export enmtools.maxent
@@ -16,7 +17,7 @@
 #' enmtools.maxent(iberolacerta.clade$species$monticola, env = euro.worldclim)
 
 
-enmtools.maxent <- function(species, env, test.prop = 0, nback = 1000, report = NULL, overwrite = FALSE,   ...){
+enmtools.maxent <- function(species, env, test.prop = 0, nback = 1000, report = NULL, overwrite = FALSE, rts.reps = 0,  ...){
 
   notes <- NULL
 
@@ -27,6 +28,7 @@ enmtools.maxent <- function(species, env, test.prop = 0, nback = 1000, report = 
   test.data <- NA
   test.evaluation <- NA
   env.test.evaluation <- NA
+  rts.test <- NA
 
   if(test.prop > 0 & test.prop < 1){
     test.inds <- sample(1:nrow(species$presence.points), ceiling(nrow(species$presence.points) * test.prop))
@@ -63,6 +65,117 @@ enmtools.maxent <- function(species, env, test.prop = 0, nback = 1000, report = 
     env.test.evaluation <- env.evaluate(temp.sp, this.mx, env)
   }
 
+  # Do Raes and ter Steege test for significance.  Turned off if eval == FALSE
+  if(rts.reps > 0){
+
+    rts.models <- list()
+
+    rts.geog.training <- c()
+    rts.geog.test <- c()
+    rts.env.training <- c()
+    rts.env.test <- c()
+
+    for(i in 1:rts.reps){
+
+      # Repeating analysis with scrambled pa points and then evaluating models
+      rts.df <- analysis.df
+      rts.df$presence <- rts.df$presence[sample(1:nrow(rts.df))]
+      this.mx <- maxent(env, p = rts.df[rts.df$presence == 1,1:2], a = rts.df[rts.df$presence == 0,1:2], ...)
+
+      suitability <- predict(env, this.mx, type = "response")
+
+      thisrep.model.evaluation <-dismo::evaluate(species$presence.points[,1:2], species$background.points[,1:2],
+                                                 this.mx, env)
+      thisrep.env.model.evaluation <- env.evaluate(species, this.mx, env)
+
+      rts.geog.training[i] <- thisrep.model.evaluation@auc
+      rts.env.training[i] <- thisrep.env.model.evaluation@auc
+
+      # I need to double check whether RTS tested models on same test data as empirical
+      # model, or whether they drew new holdouts for replicates.  Currently I'm just
+      # using the same test data for each rep.
+      if(test.prop > 0 & test.prop < 1){
+        thisrep.test.evaluation <-dismo::evaluate(test.data, species$background.points[,1:2],
+                                                  this.mx, env)
+        temp.sp <- species
+        temp.sp$presence.points <- test.data
+        thisrep.env.test.evaluation <- env.evaluate(temp.sp, this.mx, env)
+
+        rts.geog.test[i] <- thisrep.test.evaluation@auc
+        rts.env.test[i] <- thisrep.env.test.evaluation@auc
+      }
+      rts.models[[paste0("rep.",i)]] <- list(model = this.mx,
+                                             training.evaluation = model.evaluation,
+                                             env.training.evaluation = env.model.evaluation,
+                                             test.evaluation = test.evaluation,
+                                             env.test.evaluation = env.test.evaluation)
+    }
+
+    # Reps are all run now, time to package it all up
+
+    # Calculating p values
+    rts.geog.training.pvalue = mean(rts.geog.training > model.evaluation@auc)
+    rts.env.training.pvalue = mean(rts.env.training > env.model.evaluation@auc)
+    if(test.prop > 0){
+      rts.geog.test.pvalue <- mean(rts.geog.test > test.evaluation@auc)
+      rts.env.test.pvalue <- mean(rts.env.test > env.test.evaluation@auc)
+    } else {
+      rts.geog.test.pvalue <- NA
+      rts.env.test.pvalue <- NA
+    }
+
+    # Making plots
+    training.plot <- qplot(rts.geog.training, geom = "histogram", fill = "density", alpha = 0.5) +
+      geom_vline(xintercept = model.evaluation@auc, linetype = "longdash") +
+      xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+      ggtitle(paste("Model performance in geographic space on training data")) +
+      theme(plot.title = element_text(hjust = 0.5))
+
+    env.training.plot <- qplot(rts.env.training, geom = "histogram", fill = "density", alpha = 0.5) +
+      geom_vline(xintercept = env.model.evaluation@auc, linetype = "longdash") +
+      xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+      ggtitle(paste("Model performance in environmental space on training data")) +
+      theme(plot.title = element_text(hjust = 0.5))
+
+    # Make plots for test AUC distributions
+    if(test.prop > 0){
+      test.plot <- qplot(rts.geog.test, geom = "histogram", fill = "density", alpha = 0.5) +
+        geom_vline(xintercept = test.evaluation@auc, linetype = "longdash") +
+        xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+        ggtitle(paste("Model performance in geographic space on test data")) +
+        theme(plot.title = element_text(hjust = 0.5))
+
+      env.test.plot <- qplot(rts.env.test, geom = "histogram", fill = "density", alpha = 0.5) +
+        geom_vline(xintercept = env.test.evaluation@auc, linetype = "longdash") +
+        xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+        ggtitle(paste("Model performance in environmental space on test data")) +
+        theme(plot.title = element_text(hjust = 0.5))
+    } else {
+      test.plot <- NA
+      env.test.plot <- NA
+    }
+
+    rts.pvalues = list(rts.geog.training.pvalue = rts.geog.training.pvalue,
+                       rts.env.training.pvalue = rts.env.training.pvalue,
+                       rts.geog.test.pvalue = rts.geog.test.pvalue,
+                       rts.env.test.pvalue = rts.env.test.pvalue)
+    rts.distributions = list(rts.geog.training = rts.geog.training,
+                             rts.env.training = rts.env.training,
+                             rts.geog.test = rts.geog.test,
+                             rts.env.test = rts.env.test)
+    rts.plots = list(geog.training.plot = training.plot,
+                     env.training.plot = env.training.plot,
+                     geog.test.plot = test.plot,
+                     env.test.plot = env.test.plot)
+
+    rts.test <- list(rts.models = rts.models,
+                     rts.pvalues = rts.pvalues,
+                     rts.distributions = rts.distributions,
+                     rts.plots = rts.plots,
+                     rts.nreps = rts.reps)
+  }
+
+
   suitability <- predict(env, this.mx, type = "response")
 
 
@@ -75,6 +188,7 @@ enmtools.maxent <- function(species, env, test.prop = 0, nback = 1000, report = 
                  test.evaluation = test.evaluation,
                  env.training.evaluation = env.model.evaluation,
                  env.test.evaluation = env.test.evaluation,
+                 rts.test = rts.test,
                  suitability = suitability,
                  notes = notes)
 

--- a/R/enmtools.ppmlasso.R
+++ b/R/enmtools.ppmlasso.R
@@ -9,6 +9,7 @@
 #' @param normalise Should the suitability of the model be normalised? If FALSE (the default), suitability is returned as the predicted number of presence points in each grid cell (occurrence density). If TRUE, occurrence densities are divided by the total predicted density, to give a value ranging from 0 to 1, which represents the proportion of the predicted density for a species that occurs in each grid cell.
 #' @param report Optional name of an html file for generating reports
 #' @param overwrite TRUE/FALSE whether to overwrite a report file if it already exists
+#' @param rts.reps The number of replicates to do for a Raes and ter Steege-style test of significance
 #' @param ... Arguments to be passed to ppmlasso()
 #'
 #' @details This runs a \code{ppmlasso} model of a species' distribution. It is generally recommended that background points should be on a grid for this method, as the background points are considered 'quadrature' points, used to estimate an integral. If background points are not provided, the function will generate them on a grid, rather than randomly, as is more usual for other SDM methods.
@@ -22,7 +23,7 @@
 #' enmtools.ppmlasso(iberolacerta.clade$species$monticola, env = euro.worldclim[[1:3]])
 
 
-enmtools.ppmlasso <- function(species, env, f = NULL, test.prop = 0, eval = TRUE, nback = 10000, normalise = FALSE, report = NULL, overwrite = FALSE, ...){
+enmtools.ppmlasso <- function(species, env, f = NULL, test.prop = 0, eval = TRUE, nback = 10000, normalise = FALSE, report = NULL, overwrite = FALSE, rts.reps = 0, ...){
 
   notes <- NULL
 
@@ -42,6 +43,7 @@ enmtools.ppmlasso <- function(species, env, f = NULL, test.prop = 0, eval = TRUE
   env.model.evaluation <- NA
   test.evaluation <- NA
   env.test.evaluation <- NA
+  rts.test <- NA
 
 
   ### Add env data

--- a/R/enmtools.rf.R
+++ b/R/enmtools.rf.R
@@ -8,6 +8,7 @@
 #' @param nback Number of background points to draw from range or env, if background points aren't provided
 #' @param report Optional name of an html file for generating reports
 #' @param overwrite TRUE/FALSE whether to overwrite a report file if it already exists
+#' @param rts.reps The number of replicates to do for a Raes and ter Steege-style test of significance
 #' @param ... Arguments to be passed to rf()
 #'
 #' @export enmtools.rf
@@ -18,7 +19,7 @@
 #' data(iberolacerta.clade)
 #' enmtools.rf(iberolacerta.clade$species$monticola, env = euro.worldclim, nback = 500)
 
-enmtools.rf <- function(species, env, f = NULL, test.prop = 0, eval = TRUE, nback = 1000, report = NULL, overwrite = FALSE, ...){
+enmtools.rf <- function(species, env, f = NULL, test.prop = 0, eval = TRUE, nback = 1000, report = NULL, overwrite = FALSE, rts.reps = 0, ...){
 
   notes <- NULL
 
@@ -38,6 +39,7 @@ enmtools.rf <- function(species, env, f = NULL, test.prop = 0, eval = TRUE, nbac
   env.model.evaluation <- NA
   test.evaluation <- NA
   env.test.evaluation <- NA
+  rts.test <- NA
 
   if(test.prop > 0 & test.prop < 1){
     test.inds <- sample(1:nrow(species$presence.points), ceiling(nrow(species$presence.points) * test.prop))
@@ -82,6 +84,115 @@ enmtools.rf <- function(species, env, f = NULL, test.prop = 0, eval = TRUE, nbac
       env.test.evaluation <- env.evaluate(temp.sp, this.rf, env)
     }
 
+    # Do Raes and ter Steege test for significance.  Turned off if eval == FALSE
+    if(rts.reps > 0 && eval == TRUE){
+
+      rts.models <- list()
+
+      rts.geog.training <- c()
+      rts.geog.test <- c()
+      rts.env.training <- c()
+      rts.env.test <- c()
+
+      for(i in 1:rts.reps){
+
+        # Repeating analysis with scrambled pa points and then evaluating models
+        rts.df <- analysis.df
+        rts.df$presence <- rts.df$presence[sample(1:nrow(rts.df))]
+        this.rf <- randomForest(f, rts.df[,-c(1,2)], family="binomial", ...)
+
+        suitability <- predict(env, this.rf, type = "response")
+
+        thisrep.model.evaluation <-dismo::evaluate(species$presence.points[,1:2], species$background.points[,1:2],
+                                                   this.rf, env)
+        thisrep.env.model.evaluation <- env.evaluate(species, this.rf, env)
+
+        rts.geog.training[i] <- thisrep.model.evaluation@auc
+        rts.env.training[i] <- thisrep.env.model.evaluation@auc
+
+        # I need to double check whether RTS tested models on same test data as empirical
+        # model, or whether they drew new holdouts for replicates.  Currently I'm just
+        # using the same test data for each rep.
+        if(test.prop > 0 & test.prop < 1){
+          thisrep.test.evaluation <-dismo::evaluate(test.data, species$background.points[,1:2],
+                                                    this.rf, env)
+          temp.sp <- species
+          temp.sp$presence.points <- test.data
+          thisrep.env.test.evaluation <- env.evaluate(temp.sp, this.rf, env)
+
+          rts.geog.test[i] <- thisrep.test.evaluation@auc
+          rts.env.test[i] <- thisrep.env.test.evaluation@auc
+        }
+        rts.models[[paste0("rep.",i)]] <- list(model = this.rf,
+                                               training.evaluation = model.evaluation,
+                                               env.training.evaluation = env.model.evaluation,
+                                               test.evaluation = test.evaluation,
+                                               env.test.evaluation = env.test.evaluation)
+      }
+
+      # Reps are all run now, time to package it all up
+
+      # Calculating p values
+      rts.geog.training.pvalue = mean(rts.geog.training > model.evaluation@auc)
+      rts.env.training.pvalue = mean(rts.env.training > env.model.evaluation@auc)
+      if(test.prop > 0){
+        rts.geog.test.pvalue <- mean(rts.geog.test > test.evaluation@auc)
+        rts.env.test.pvalue <- mean(rts.env.test > env.test.evaluation@auc)
+      } else {
+        rts.geog.test.pvalue <- NA
+        rts.env.test.pvalue <- NA
+      }
+
+      # Making plots
+      training.plot <- qplot(rts.geog.training, geom = "histogram", fill = "density", alpha = 0.5) +
+        geom_vline(xintercept = model.evaluation@auc, linetype = "longdash") +
+        xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+        ggtitle(paste("Model performance in geographic space on training data")) +
+        theme(plot.title = element_text(hjust = 0.5))
+
+      env.training.plot <- qplot(rts.env.training, geom = "histogram", fill = "density", alpha = 0.5) +
+        geom_vline(xintercept = env.model.evaluation@auc, linetype = "longdash") +
+        xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+        ggtitle(paste("Model performance in environmental space on training data")) +
+        theme(plot.title = element_text(hjust = 0.5))
+
+      # Make plots for test AUC distributions
+      if(test.prop > 0){
+        test.plot <- qplot(rts.geog.test, geom = "histogram", fill = "density", alpha = 0.5) +
+          geom_vline(xintercept = test.evaluation@auc, linetype = "longdash") +
+          xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+          ggtitle(paste("Model performance in geographic space on test data")) +
+          theme(plot.title = element_text(hjust = 0.5))
+
+        env.test.plot <- qplot(rts.env.test, geom = "histogram", fill = "density", alpha = 0.5) +
+          geom_vline(xintercept = env.test.evaluation@auc, linetype = "longdash") +
+          xlim(0,1) + guides(fill = FALSE, alpha = FALSE) + xlab("D") +
+          ggtitle(paste("Model performance in environmental space on test data")) +
+          theme(plot.title = element_text(hjust = 0.5))
+      } else {
+        test.plot <- NA
+        env.test.plot <- NA
+      }
+
+      rts.pvalues = list(rts.geog.training.pvalue = rts.geog.training.pvalue,
+                         rts.env.training.pvalue = rts.env.training.pvalue,
+                         rts.geog.test.pvalue = rts.geog.test.pvalue,
+                         rts.env.test.pvalue = rts.env.test.pvalue)
+      rts.distributions = list(rts.geog.training = rts.geog.training,
+                               rts.env.training = rts.env.training,
+                               rts.geog.test = rts.geog.test,
+                               rts.env.test = rts.env.test)
+      rts.plots = list(geog.training.plot = training.plot,
+                       env.training.plot = env.training.plot,
+                       geog.test.plot = test.plot,
+                       env.test.plot = env.test.plot)
+
+      rts.test <- list(rts.models = rts.models,
+                       rts.pvalues = rts.pvalues,
+                       rts.distributions = rts.distributions,
+                       rts.plots = rts.plots,
+                       rts.nreps = rts.reps)
+    }
   }
 
   output <- list(species.name = species$species.name,
@@ -94,6 +205,7 @@ enmtools.rf <- function(species, env, f = NULL, test.prop = 0, eval = TRUE, nbac
                  test.evaluation = test.evaluation,
                  env.training.evaluation = env.model.evaluation,
                  env.test.evaluation = env.test.evaluation,
+                 rts.test = rts.test,
                  suitability = suitability,
                  notes = notes)
 


### PR DESCRIPTION
Now all modeling functions except ppmlasso (which I’ll leave to
Russell) accept an rts.reps argument.  When a number greater than zero
is passed for this argument, the function performs that many R&tS
permutation tests.  It returns plots, distributions, and p values as
well as replicate models.