### PR TITLE
Added code to auomatically do PCA in ecospat tests

### DIFF
--- a/R/enmtools.ecospat.bg.R
+++ b/R/enmtools.ecospat.bg.R
@@ -4,7 +4,7 @@
 #' @param species.2 An enmtools.species object
 #' @param env A set of environmental layers
 #' @param nreps The number of pseudoreplicates to perform
-#' @param layers A vector of length 2 containing the names of the layers to be used.
+#' @param layers A vector of length 2 containing the names of the layers to be used.  If no layer names are provided and there are more than two layers in env, enmtools will perform a pca and use the top two layers from that.
 #' @param test.type Symmetric or asymmetric test.  An asymmetric test is bguivalent to the "one.sided" option in the ecospat documentation, while a symmetric one would be two-sided.
 #' @param th.sp Quantile of species densities used as a threshold to exclude low species density values.  See documentation for ecospat.grid.clim.dyn.
 #' @param th.env Quantile of environmental densities across studye sites used as threshold to exclude low
@@ -31,8 +31,35 @@ enmtools.ecospat.bg <- function(species.1, species.2, env, nreps = 99, layers = 
   species.1 <- check.bg(species.1, env, nback)
   species.2 <- check.bg(species.2, env, nback)
 
+  # Use supplied layers if there's two of them, otherwise do PCA
   if(length(names(env)) == 2){
     layers <- names(env)
+  }  else if (is.null(layers)) {
+
+    print("More than two layers in environment stack and no layers argument passed, performing PCA...")
+
+    # Get all values
+    env.val <- getValues(env)
+
+    # Figure out which cells have complete cases and which have at least one NA
+    keepers <- which(complete.cases(env.val))
+    nas <- which(!complete.cases(env.val))
+
+    # Do PCA
+    pca <- princomp(env.val[keepers,], cor=T)
+
+    # Build dummy layers
+    env.pca <- env[[1:2]]
+
+    # Add scores and NAs where appropriate
+    env.pca[nas] <- NA
+    env.pca[[1]][keepers] <- pca$scores[,1]
+    env.pca[[2]][keepers] <- pca$scores[,2]
+
+    # Rename layers and ship it out
+    names(env.pca) <- c("PC1", "PC2")
+    layers <- names(env.pca)
+    env <- env.pca
   }
 
   ecospat.bg.precheck(species.1, species.2, env, nreps, layers)

--- a/man/enmtools.ecospat.bg.Rd
+++ b/man/enmtools.ecospat.bg.Rd
@@ -17,7 +17,7 @@ enmtools.ecospat.bg(species.1, species.2, env, nreps = 99, layers = NULL,
 
 \item{nreps}{The number of pseudoreplicates to perform}
 
-\item{layers}{A vector of length 2 containing the names of the layers to be used.}
+\item{layers}{A vector of length 2 containing the names of the layers to be used.  If no layer names are provided and there are more than two layers in env, enmtools will perform a pca and use the top two layers from that.}
 
 \item{test.type}{Symmetric or asymmetric test.  An asymmetric test is bguivalent to the "one.sided" option in the ecospat documentation, while a symmetric one would be two-sided.}
 

--- a/man/enmtools.ecospat.id.Rd
+++ b/man/enmtools.ecospat.id.Rd
@@ -16,7 +16,7 @@ enmtools.ecospat.id(species.1, species.2, env, nreps = 99, layers = NULL,
 
 \item{nreps}{The number of pseudoreplicates to perform}
 
-\item{layers}{A vector of length 2 containing the names of the layers to be used.}
+\item{layers}{A vector of length 2 containing the names of the layers to be used.  If no layer names are provided and there are more than two layers in env, enmtools will perform a pca and use the top two layers from that.}
 
 \item{th.sp}{Quantile of species densities used as a threshold to exclude low species density values.  See documentation for ecospat.grid.clim.dyn.}
 


### PR DESCRIPTION
Now if you call an ecospat test there are three possibilities for env
layers:

1.  Only two layers provided, use those.
2. More than two layers provided but you pass a layers argument that
tells it which ones to use.
3. More than two layers provided but no layers argument, in which case
it does a PCA and takes the top two layers from that.