### PR TITLE
Added tree overlap plot to enmtools.aoc

### DIFF
--- a/R/enmtools.aoc.R
+++ b/R/enmtools.aoc.R
@@ -162,6 +162,8 @@ print.enmtools.aoc <- function(x, ...){
 }
 
 plot.enmtools.aoc <- function(x, ...){
+  plot(x$tree, no.margin=TRUE, edge.width=2, cex=1)
+  nodelabels(format(x$empirical.df$overlap, digits = 1, nsmall = 2))
 
   grid.arrange(x$regressions.plot, x$intercept.plot,
                x$slope.plot, ncol = 2) +


### PR DESCRIPTION
Now when you plot an enmtools.aoc object you get two plots.  One is for the statistical test as before, and the other is a tree with the phylogenetically averaged overlap values on the nodes.