### PR TITLE
Low memory options for Monte Carlo tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Maintainer: Dan Warren <dan.l.warren@gmail.com>
 Description: Tools for the ecological and historical biogeography.
 License: GPL-2
 LazyData: TRUE
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 Imports:
 	rgeos,
 	knitr,

--- a/R/enmtools.dm.R
+++ b/R/enmtools.dm.R
@@ -8,7 +8,7 @@
 #' @param nback Number of background points for models.  In the case of Domain, these are only used for evaluation.
 #' @param rts.reps The number of replicates to do for a Raes and ter Steege-style test of significance
 #' @param bg.source Source for drawing background points.  If "points", it just uses the background points that are already in the species object.  If "range", it uses the range raster.  If "env", it draws points at randome from the entire study area outlined by the first environmental layer.
-#' @param ... Arguments to be passed to bioclim()
+#' @param ... Arguments to be passed to domain()
 #'
 #' @examples
 #' \dontrun{

--- a/R/rangebreak.blob.R
+++ b/R/rangebreak.blob.R
@@ -28,7 +28,7 @@
 #' }
 
 
-rangebreak.blob <- function(species.1, species.2, env, type, f = NULL, nreps = 99, nback = 1000, bg.source = "default", ...){
+rangebreak.blob <- function(species.1, species.2, env, type, f = NULL, nreps = 99, nback = 1000, bg.source = "default", low.memory = FALSE, rep.dir = NA, ...){
 
   # Just for visualization
   plotraster <- env[[1]]

--- a/R/rangebreak.blob.R
+++ b/R/rangebreak.blob.R
@@ -9,6 +9,8 @@
 #' @param nreps Number of replicates to perform
 #' @param nback Number of background points for models
 #' @param bg.source Source for drawing background points.  If "points", it just uses the background points that are already in the species object.  If "range", it uses the range raster.  If "env", it draws points at randome from the entire study area outlined by the first environmental layer.
+#' @param low.memory When set to TRUE, replicate models are written to disc instead of being stored in the output object.  Replicate models stored in the output object contain paths to the replicate models on disk instead of the rasters themselves.
+#' @param rep.dir Directory for storing replicate models when low.memory is set to TRUE.  If not specified, the working directory will be used.
 #' @param ... Additional arguments to be passed to model fitting functions.
 #'
 #' @return results A list containing a replicates, models for the empirical data, and summary statistics and plots.
@@ -39,6 +41,21 @@ rangebreak.blob <- function(species.1, species.2, env, type, f = NULL, nreps = 9
 
   # Initialize a list to store reps in
   replicate.models <- list()
+
+  # Set the output directory when low.memory = TRUE
+  if(low.memory == TRUE){
+    if(is.na(rep.dir)){
+      rep.dir <- getwd()
+    }
+
+    if(substr(rep.dir, nchar(rep.dir), nchar(rep.dir)) != "/"){
+      rep.dir <- paste0(rep.dir, "/")
+    }
+
+    if(!dir.exists(rep.dir)){
+      stop(paste("Specified directory for storing replicates cannot be found!\n\n", getwd()))
+    }
+  }
 
   # For starters we need to combine species background points so that each model
   # is being built with the same background
@@ -141,8 +158,18 @@ rangebreak.blob <- function(species.1, species.2, env, type, f = NULL, nreps = 9
     }
 
     # Appending models to replicates list
-    replicate.models[[paste0(species.1$species.name, ".rep.", i)]] <- rep.species.1.model
-    replicate.models[[paste0(species.2$species.name, ".rep.", i)]] <- rep.species.2.model
+    if(low.memory == TRUE){
+      path.1 <- paste0(rep.dir, species.1$species.name, ".rep.", i, ".Rda")
+      path.2 <- paste0(rep.dir, species.2$species.name, ".rep.", i, ".Rda")
+      save(rep.species.1.model, file = path.1)
+      save(rep.species.2.model, file = path.2)
+      replicate.models[[paste0(species.1$species.name, ".rep.", i)]] <- path.1
+      replicate.models[[paste0(species.2$species.name, ".rep.", i)]] <- path.2
+
+    } else {
+      replicate.models[[paste0(species.1$species.name, ".rep.", i)]] <- rep.species.1.model
+      replicate.models[[paste0(species.2$species.name, ".rep.", i)]] <- rep.species.2.model
+    }
 
     reps.overlap <- rbind(reps.overlap, c(unlist(raster.overlap(rep.species.1.model, rep.species.2.model)),
                                           unlist(env.overlap(rep.species.1.model, rep.species.2.model, env = env)[1:3])))

--- a/R/rangebreak.linear.R
+++ b/R/rangebreak.linear.R
@@ -9,6 +9,8 @@
 #' @param nreps Number of replicates to perform
 #' @param nback Number of background points for models
 #' @param bg.source Source for drawing background points.  If "points", it just uses the background points that are already in the species object.  If "range", it uses the range raster.  If "env", it draws points at randome from the entire study area outlined by the first environmental layer.
+#' @param low.memory When set to TRUE, replicate models are written to disc instead of being stored in the output object.  Replicate models stored in the output object contain paths to the replicate models on disk instead of the rasters themselves.
+#' @param rep.dir Directory for storing replicate models when low.memory is set to TRUE.  If not specified, the working directory will be used.
 #' @param ... Additional arguments to be passed to model fitting functions.
 #'
 #' @return results A list containing a replicates, models for the empirical data, and summary statistics and plots.
@@ -38,6 +40,21 @@ rangebreak.linear <- function(species.1, species.2, env, type, f = NULL, nreps =
 
   # Initialize a list to store reps in
   replicate.models <- list()
+
+  # Set the output directory when low.memory = TRUE
+  if(low.memory == TRUE){
+    if(is.na(rep.dir)){
+      rep.dir <- getwd()
+    }
+
+    if(substr(rep.dir, nchar(rep.dir), nchar(rep.dir)) != "/"){
+      rep.dir <- paste0(rep.dir, "/")
+    }
+
+    if(!dir.exists(rep.dir)){
+      stop(paste("Specified directory for storing replicates cannot be found!\n\n", getwd()))
+    }
+  }
 
   # For starters we need to combine species background points so that each model
   # is being built with the same background
@@ -151,8 +168,18 @@ rangebreak.linear <- function(species.1, species.2, env, type, f = NULL, nreps =
     }
 
     # Appending models to replicates list
-    replicate.models[[paste0(species.1$species.name, ".rep.", i)]] <- rep.species.1.model
-    replicate.models[[paste0(species.2$species.name, ".rep.", i)]] <- rep.species.2.model
+    if(low.memory == TRUE){
+      path.1 <- paste0(rep.dir, species.1$species.name, ".rep.", i, ".Rda")
+      path.2 <- paste0(rep.dir, species.2$species.name, ".rep.", i, ".Rda")
+      save(rep.species.1.model, file = path.1)
+      save(rep.species.2.model, file = path.2)
+      replicate.models[[paste0(species.1$species.name, ".rep.", i)]] <- path.1
+      replicate.models[[paste0(species.2$species.name, ".rep.", i)]] <- path.2
+
+    } else {
+      replicate.models[[paste0(species.1$species.name, ".rep.", i)]] <- rep.species.1.model
+      replicate.models[[paste0(species.2$species.name, ".rep.", i)]] <- rep.species.2.model
+    }
 
     reps.overlap <- rbind(reps.overlap, c(unlist(raster.overlap(rep.species.1.model, rep.species.2.model)),
                                           unlist(env.overlap(rep.species.1.model, rep.species.2.model, env = env)[1:3])))

--- a/R/rangebreak.linear.R
+++ b/R/rangebreak.linear.R
@@ -27,7 +27,7 @@
 #' f= pres ~ bio1 + bio12, nreps = 10)
 #' }
 
-rangebreak.linear <- function(species.1, species.2, env, type, f = NULL, nreps = 99,  nback = 1000, bg.source = "default", ...){
+rangebreak.linear <- function(species.1, species.2, env, type, f = NULL, nreps = 99,  nback = 1000, bg.source = "default", low.memory = FALSE, rep.dir = NA, ...){
 
   # Just for visualization
   #   plotraster <- env[[1]]

--- a/R/rangebreak.ribbon.R
+++ b/R/rangebreak.ribbon.R
@@ -36,7 +36,7 @@
 #' type = "glm", f= pres ~ bio1 + bio12, nreps = 10)
 #' }
 
-rangebreak.ribbon <- function(species.1, species.2, ribbon, env, type, f = NULL, width = 1, nreps = 99,  nback = 1000, bg.source = "default", ...){
+rangebreak.ribbon <- function(species.1, species.2, ribbon, env, type, f = NULL, width = 1, nreps = 99,  nback = 1000, bg.source = "default", low.memory = FALSE, rep.dir = NA, ...){
 
   species.1 <- check.bg(species.1, env, nback = nback, bg.source = bg.source)
   species.2 <- check.bg(species.2, env, nback = nback, bg.source = bg.source)
@@ -252,16 +252,16 @@ rangebreak.ribbon <- function(species.1, species.2, ribbon, env, type, f = NULL,
 
     # Appending models to replicates list
     if(low.memory == TRUE){
-      path.1 <- paste0(rep.dir, species.1$species.name, ".rep.", i, ".Rda")
-      path.2 <- paste0(rep.dir, species.2$species.name, ".rep.", i, ".Rda")
-      path.ribbon <- paste0(rep.dir, "ribbon.rep.", i, ".Rda")
-      path.outside <- paste0(rep.dir, "outside.rep.", i, ".Rda")
+      path.1 <- paste0(rep.dir, species.1$species.name, ".rep.", keepers, ".Rda")
+      path.2 <- paste0(rep.dir, species.2$species.name, ".rep.", keepers, ".Rda")
+      path.ribbon <- paste0(rep.dir, "ribbon.rep.", keepers, ".Rda")
+      path.outside <- paste0(rep.dir, "outside.rep.", keepers, ".Rda")
       save(rep.species.1.model, file = path.1)
       save(rep.species.2.model, file = path.2)
       save(rep.ribbon.model, file = path.ribbon)
       save(rep.outside.model, file = path.outside)
-      replicate.models[[paste0(species.1$species.name, ".rep.", i)]] <- path.1
-      replicate.models[[paste0(species.2$species.name, ".rep.", i)]] <- path.2
+      replicate.models[[paste0(species.1$species.name, ".rep.", keepers)]] <- path.1
+      replicate.models[[paste0(species.2$species.name, ".rep.", keepers)]] <- path.2
       replicate.models[[paste0("ribbon.rep.", keepers)]] <- path.ribbon
       replicate.models[[paste0("outside.rep.", keepers)]] <- path.outside
 

--- a/R/rangebreak.ribbon.R
+++ b/R/rangebreak.ribbon.R
@@ -11,6 +11,8 @@
 #' @param nreps Number of replicates to perform
 #' @param nback Number of background points for models
 #' @param bg.source Source for drawing background points.  If "points", it just uses the background points that are already in the species object.  If "range", it uses the range raster.  If "env", it draws points at randome from the entire study area outlined by the first environmental layer.
+#' @param low.memory When set to TRUE, replicate models are written to disc instead of being stored in the output object.  Replicate models stored in the output object contain paths to the replicate models on disk instead of the rasters themselves.
+#' @param rep.dir Directory for storing replicate models when low.memory is set to TRUE.  If not specified, the working directory will be used.
 #' @param ... Additional arguments to be passed to model fitting functions.
 #'
 #' @return results A list containing a replicates, models for the empirical data, and summary statistics and plots.
@@ -56,6 +58,21 @@ rangebreak.ribbon <- function(species.1, species.2, ribbon, env, type, f = NULL,
 
   # Initialize a list to store reps in
   replicate.models <- list()
+
+  # Set the output directory when low.memory = TRUE
+  if(low.memory == TRUE){
+    if(is.na(rep.dir)){
+      rep.dir <- getwd()
+    }
+
+    if(substr(rep.dir, nchar(rep.dir), nchar(rep.dir)) != "/"){
+      rep.dir <- paste0(rep.dir, "/")
+    }
+
+    if(!dir.exists(rep.dir)){
+      stop(paste("Specified directory for storing replicates cannot be found!\n\n", getwd()))
+    }
+  }
 
   # For starters we need to combine species background points so that each model
   # is being built with the same background
@@ -231,11 +248,30 @@ rangebreak.ribbon <- function(species.1, species.2, ribbon, env, type, f = NULL,
       rep.outside.model <- enmtools.rf(rep.outside, env, ...)
     }
 
+
+
     # Appending models to replicates list
-    replicate.models[[paste0(species.1$species.name, ".rep.", keepers)]] <- rep.species.1.model
-    replicate.models[[paste0(species.2$species.name, ".rep.", keepers)]] <- rep.species.2.model
-    replicate.models[[paste0("ribbon.rep.", keepers)]] <- rep.ribbon.model
-    replicate.models[[paste0("outside.rep.", keepers)]] <- rep.outside.model
+    if(low.memory == TRUE){
+      path.1 <- paste0(rep.dir, species.1$species.name, ".rep.", i, ".Rda")
+      path.2 <- paste0(rep.dir, species.2$species.name, ".rep.", i, ".Rda")
+      path.ribbon <- paste0(rep.dir, "ribbon.rep.", i, ".Rda")
+      path.outside <- paste0(rep.dir, "outside.rep.", i, ".Rda")
+      save(rep.species.1.model, file = path.1)
+      save(rep.species.2.model, file = path.2)
+      save(rep.ribbon.model, file = path.ribbon)
+      save(rep.outside.model, file = path.outside)
+      replicate.models[[paste0(species.1$species.name, ".rep.", i)]] <- path.1
+      replicate.models[[paste0(species.2$species.name, ".rep.", i)]] <- path.2
+      replicate.models[[paste0("ribbon.rep.", keepers)]] <- path.ribbon
+      replicate.models[[paste0("outside.rep.", keepers)]] <- path.outside
+
+    } else {
+      replicate.models[[paste0(species.1$species.name, ".rep.", keepers)]] <- rep.species.1.model
+      replicate.models[[paste0(species.2$species.name, ".rep.", keepers)]] <- rep.species.2.model
+      replicate.models[[paste0("ribbon.rep.", keepers)]] <- rep.ribbon.model
+      replicate.models[[paste0("outside.rep.", keepers)]] <- rep.outside.model
+    }
+
 
     # Measure overlaps
     this.overlap.sp1.vs.sp2  <- c(unlist(raster.overlap(rep.species.1.model, rep.species.2.model)),

--- a/man/background.test.Rd
+++ b/man/background.test.Rd
@@ -9,7 +9,8 @@ constructed from the background points supplied for each species.  For Maxent, t
 from the range rasters stored in the enmtools.species objects.}
 \usage{
 background.test(species.1, species.2, env, type, f = NULL, nreps = 99,
-  test.type = "asymmetric", nback = 1000, bg.source = "default", ...)
+  test.type = "asymmetric", nback = 1000, bg.source = "default",
+  low.memory = FALSE, rep.dir = NA, ...)
 }
 \arguments{
 \item{species.1}{An emtools.species object from which presence points (asymmetric) or background (symmetric) will be sampled.}
@@ -29,6 +30,10 @@ background.test(species.1, species.2, env, type, f = NULL, nreps = 99,
 \item{nback}{Number of background points for models}
 
 \item{bg.source}{Source for drawing background points.  If "points", it just uses the background points that are already in the species object.  If "range", it uses the range raster.  If "env", it draws points at randome from the entire study area outlined by the first environmental layer.}
+
+\item{low.memory}{When set to TRUE, replicate models are written to disc instead of being stored in the output object.  Replicate models stored in the output object contain paths to the replicate models on disk instead of the rasters themselves.}
+
+\item{rep.dir}{Directory for storing replicate models when low.memory is set to TRUE.  If not specified, the working directory will be used.}
 
 \item{...}{Additional arguments to be passed to model fitting functions.}
 }

--- a/man/enmtools.dm.Rd
+++ b/man/enmtools.dm.Rd
@@ -25,7 +25,7 @@ enmtools.dm(species, env = NA, test.prop = 0, report = NULL,
 
 \item{bg.source}{Source for drawing background points.  If "points", it just uses the background points that are already in the species object.  If "range", it uses the range raster.  If "env", it draws points at randome from the entire study area outlined by the first environmental layer.}
 
-\item{...}{Arguments to be passed to bioclim()}
+\item{...}{Arguments to be passed to domain()}
 }
 \description{
 Takes an emtools.species object with presence and background points, and builds a Domain model

--- a/man/identity.test.Rd
+++ b/man/identity.test.Rd
@@ -5,7 +5,8 @@
 \title{identity.test Conduct a niche identity/equivalency test as described in Warren et al. 2008.}
 \usage{
 identity.test(species.1, species.2, env, type, f = NULL, nreps = 99,
-  nback = 1000, bg.source = "default", ...)
+  nback = 1000, bg.source = "default", low.memory = FALSE,
+  rep.dir = NA, ...)
 }
 \arguments{
 \item{species.1}{An emtools.species object}
@@ -23,6 +24,10 @@ identity.test(species.1, species.2, env, type, f = NULL, nreps = 99,
 \item{nback}{Number of background points for models}
 
 \item{bg.source}{Source for drawing background points.  If "points", it just uses the background points that are already in the species object.  If "range", it uses the range raster.  If "env", it draws points at randome from the entire study area outlined by the first environmental layer.}
+
+\item{low.memory}{When set to TRUE, replicate models are written to disc instead of being stored in the output object.  Replicate models stored in the output object contain paths to the replicate models on disk instead of the rasters themselves.}
+
+\item{rep.dir}{Directory for storing replicate models when low.memory is set to TRUE.  If not specified, the working directory will be used.}
 
 \item{...}{Additional arguments to be passed to model fitting functions.}
 }

--- a/man/rangebreak.blob.Rd
+++ b/man/rangebreak.blob.Rd
@@ -5,7 +5,8 @@
 \title{rangebreak.blob Conduct a blob rangebreak test as described in Glor and Warren 2011.}
 \usage{
 rangebreak.blob(species.1, species.2, env, type, f = NULL, nreps = 99,
-  nback = 1000, bg.source = "default", ...)
+  nback = 1000, bg.source = "default", low.memory = FALSE,
+  rep.dir = NA, ...)
 }
 \arguments{
 \item{species.1}{An emtools.species object}
@@ -24,11 +25,11 @@ rangebreak.blob(species.1, species.2, env, type, f = NULL, nreps = 99,
 
 \item{bg.source}{Source for drawing background points.  If "points", it just uses the background points that are already in the species object.  If "range", it uses the range raster.  If "env", it draws points at randome from the entire study area outlined by the first environmental layer.}
 
-\item{...}{Additional arguments to be passed to model fitting functions.}
-
 \item{low.memory}{When set to TRUE, replicate models are written to disc instead of being stored in the output object.  Replicate models stored in the output object contain paths to the replicate models on disk instead of the rasters themselves.}
 
 \item{rep.dir}{Directory for storing replicate models when low.memory is set to TRUE.  If not specified, the working directory will be used.}
+
+\item{...}{Additional arguments to be passed to model fitting functions.}
 }
 \value{
 results A list containing a replicates, models for the empirical data, and summary statistics and plots.

--- a/man/rangebreak.blob.Rd
+++ b/man/rangebreak.blob.Rd
@@ -25,6 +25,10 @@ rangebreak.blob(species.1, species.2, env, type, f = NULL, nreps = 99,
 \item{bg.source}{Source for drawing background points.  If "points", it just uses the background points that are already in the species object.  If "range", it uses the range raster.  If "env", it draws points at randome from the entire study area outlined by the first environmental layer.}
 
 \item{...}{Additional arguments to be passed to model fitting functions.}
+
+\item{low.memory}{When set to TRUE, replicate models are written to disc instead of being stored in the output object.  Replicate models stored in the output object contain paths to the replicate models on disk instead of the rasters themselves.}
+
+\item{rep.dir}{Directory for storing replicate models when low.memory is set to TRUE.  If not specified, the working directory will be used.}
 }
 \value{
 results A list containing a replicates, models for the empirical data, and summary statistics and plots.

--- a/man/rangebreak.linear.Rd
+++ b/man/rangebreak.linear.Rd
@@ -25,6 +25,10 @@ rangebreak.linear(species.1, species.2, env, type, f = NULL,
 \item{bg.source}{Source for drawing background points.  If "points", it just uses the background points that are already in the species object.  If "range", it uses the range raster.  If "env", it draws points at randome from the entire study area outlined by the first environmental layer.}
 
 \item{...}{Additional arguments to be passed to model fitting functions.}
+
+\item{low.memory}{When set to TRUE, replicate models are written to disc instead of being stored in the output object.  Replicate models stored in the output object contain paths to the replicate models on disk instead of the rasters themselves.}
+
+\item{rep.dir}{Directory for storing replicate models when low.memory is set to TRUE.  If not specified, the working directory will be used.}
 }
 \value{
 results A list containing a replicates, models for the empirical data, and summary statistics and plots.

--- a/man/rangebreak.linear.Rd
+++ b/man/rangebreak.linear.Rd
@@ -5,7 +5,8 @@
 \title{rangebreak.linear Conduct a linear rangebreak test as described in Glor and Warren 2011.}
 \usage{
 rangebreak.linear(species.1, species.2, env, type, f = NULL,
-  nreps = 99, nback = 1000, bg.source = "default", ...)
+  nreps = 99, nback = 1000, bg.source = "default",
+  low.memory = FALSE, rep.dir = NA, ...)
 }
 \arguments{
 \item{species.1}{An emtools.species object}
@@ -24,11 +25,11 @@ rangebreak.linear(species.1, species.2, env, type, f = NULL,
 
 \item{bg.source}{Source for drawing background points.  If "points", it just uses the background points that are already in the species object.  If "range", it uses the range raster.  If "env", it draws points at randome from the entire study area outlined by the first environmental layer.}
 
-\item{...}{Additional arguments to be passed to model fitting functions.}
-
 \item{low.memory}{When set to TRUE, replicate models are written to disc instead of being stored in the output object.  Replicate models stored in the output object contain paths to the replicate models on disk instead of the rasters themselves.}
 
 \item{rep.dir}{Directory for storing replicate models when low.memory is set to TRUE.  If not specified, the working directory will be used.}
+
+\item{...}{Additional arguments to be passed to model fitting functions.}
 }
 \value{
 results A list containing a replicates, models for the empirical data, and summary statistics and plots.

--- a/man/rangebreak.ribbon.Rd
+++ b/man/rangebreak.ribbon.Rd
@@ -5,7 +5,8 @@
 \title{rangebreak.ribbon Conduct a ribbon rangebreak test as described in Glor and Warren 2011.}
 \usage{
 rangebreak.ribbon(species.1, species.2, ribbon, env, type, f = NULL,
-  width = 1, nreps = 99, nback = 1000, bg.source = "default", ...)
+  width = 1, nreps = 99, nback = 1000, bg.source = "default",
+  low.memory = FALSE, rep.dir = NA, ...)
 }
 \arguments{
 \item{species.1}{An emtools.species object}
@@ -28,11 +29,11 @@ rangebreak.ribbon(species.1, species.2, ribbon, env, type, f = NULL,
 
 \item{bg.source}{Source for drawing background points.  If "points", it just uses the background points that are already in the species object.  If "range", it uses the range raster.  If "env", it draws points at randome from the entire study area outlined by the first environmental layer.}
 
-\item{...}{Additional arguments to be passed to model fitting functions.}
-
 \item{low.memory}{When set to TRUE, replicate models are written to disc instead of being stored in the output object.  Replicate models stored in the output object contain paths to the replicate models on disk instead of the rasters themselves.}
 
 \item{rep.dir}{Directory for storing replicate models when low.memory is set to TRUE.  If not specified, the working directory will be used.}
+
+\item{...}{Additional arguments to be passed to model fitting functions.}
 }
 \value{
 results A list containing a replicates, models for the empirical data, and summary statistics and plots.

--- a/man/rangebreak.ribbon.Rd
+++ b/man/rangebreak.ribbon.Rd
@@ -29,6 +29,10 @@ rangebreak.ribbon(species.1, species.2, ribbon, env, type, f = NULL,
 \item{bg.source}{Source for drawing background points.  If "points", it just uses the background points that are already in the species object.  If "range", it uses the range raster.  If "env", it draws points at randome from the entire study area outlined by the first environmental layer.}
 
 \item{...}{Additional arguments to be passed to model fitting functions.}
+
+\item{low.memory}{When set to TRUE, replicate models are written to disc instead of being stored in the output object.  Replicate models stored in the output object contain paths to the replicate models on disk instead of the rasters themselves.}
+
+\item{rep.dir}{Directory for storing replicate models when low.memory is set to TRUE.  If not specified, the working directory will be used.}
 }
 \value{
 results A list containing a replicates, models for the empirical data, and summary statistics and plots.


### PR DESCRIPTION
These changes implement "low.memory" and "reps.dir" options for all of the Monte Carlo tests (rangebreak, identity, background).  These options allow users to store replicate models on disk instead of putting them into the output object.  This reduces the RAM footprint of these models a lot.