### PR TITLE
Fixed bug in check.bg which sometime led to mismatched CRS errors

### DIFF
--- a/R/check.bg.R
+++ b/R/check.bg.R
@@ -65,7 +65,7 @@ check.bg <- function(species, env = NA, nback = 1000, bg.source = "default"){
       stop("bg.source set to range, but species does not have a recognizable range raster!")
     }
 
-    if(as.character(crs(env)) != as.character(crs(species$range))){
+    if(!raster::compareCRS(crs(env), crs(species$range))){
       stop("CRS mismatch between species range raster and environmental rasters!")
     }
 


### PR DESCRIPTION
Okay, this seems to fix the mismatched CRS issue in the example. For some reason on Windows the range raster and the env had the same projection but a different proj4 string. Instead of comparing the strings I used `raster::compareCRS()` which is a more robust way to compare anyway, since it can tell if the projection is the same, even if it was specified in slightly different but equivalent ways using proj4.