### PR TITLE
ggplot warnings recommend including after_stat instead

### DIFF
--- a/R/enmtools.vip.R
+++ b/R/enmtools.vip.R
@@ -153,7 +153,7 @@ enmtools.vip <- function(model, metric = "auc", nsim = 10, method = "permute", v
 
     output[["permute.plot"]] <- ggplot(plotdf,
                                        aes_string(x = "Importance",
-                                                  fill = "..x..")) +
+                                                  fill = after_stat("..x.."))) +
       geom_histogram(bins = 20) +
       theme_bw() +
       geom_hline(yintercept = 0, color = "grey") +


### PR DESCRIPTION
got a warning when running enmtools.vip that the '..x..' with ggplot will now be deprecated. It suggest adding after_stat instead. I added this and tested locally. The plot between `enmtools.vip` and `enmtools.vip2` differed slightly but I think this is because the nature of permutation. 